### PR TITLE
fix: 19.3 sol critical point should be (-3/2, -2), not (3/2, 2)

### DIFF
--- a/src/sol-foxtrot.typ
+++ b/src/sol-foxtrot.typ
@@ -317,7 +317,7 @@ We follow @sec-recipe-opt-easy again.
 
 We are searching for the global minimum of $f$.
 Aggregating the critical points, we check
-$ f (3 / 2 , 2) &= 25 / 4 , \
+$ f (- 3 / 2 , - 2) &= 125 / 4 , \
   f (3 , 4) &= - 25 , \
   f (- 3 , - 4) = 25 . $
 Therefore, the global minimum is $#boxed[$ f(3,4) = -25 $]$.


### PR DESCRIPTION
earlier computations give that the critical point is (-3/2, -2) (see top of page 392), and f(-3/2, -2) is 125/4, not 25/4.