### PR TITLE
fix: Proofread Part Alfa (vectors, dot, planes, cross)

### DIFF
--- a/src/cross.typ
+++ b/src/cross.typ
@@ -175,7 +175,7 @@ $ x_0 := a_2 b_3 - a_3 b_2 \
 so $x = k x_0$, $y = k y_0$, $z = k z_0$, and we need to solve for $k$.
 
 We have one more condition to use, which is that we want the magnitude
-$sqrt(x^2+y^2+z^2)$ to be equal to to the area $A$ of the parallelogram spanned by $bf(v)$ and $bf(w)$,
+$sqrt(x^2+y^2+z^2)$ to be equal to the area $A$ of the parallelogram spanned by $bf(v)$ and $bf(w)$,
 and also point in the way specified by the right-hand rule.
 How can we encode that in an equation?
 At face value, none of the weapons in our toolkit so far let you access the area of a parallelogram in 3D space.
@@ -373,7 +373,7 @@ we've seen in applications.
     table.header([Vector], [Direction], [Magnitude]),
     [Normal vector $bf(n)$ to plane], [Perpendicular to plane], [_Irrelevant!_],
     [$op("proj")_(bf(w))(bf(v))$], [Same as $bf(w)$], [Scalar component],
-    [Cross product $bf(v) times bf(w)$], [Perpendicular to both $bf(a)$ and $bf(b)$], [Area of parallelogram]
+    [Cross product $bf(v) times bf(w)$], [Perpendicular to both $bf(v)$ and $bf(w)$], [Area of parallelogram]
   ),
   caption: [Some commonly used kinds of vectors we've met so far.],
   kind: table

--- a/src/dot.typ
+++ b/src/dot.typ
@@ -8,7 +8,7 @@ one algebraic and one geometric.
 Because of that, we'll be able to get a ton of mileage out of it.
 
 This will be a general theme across the course:
-almost every new concept we define will have some sort "algebraic" side
+almost every new concept we define will have some sort of "algebraic" side
 (like the coordinates for vector addition)
 and some "geometric" side (the parallelogram in @fig-parallelogram).
 This is the bar a concept has to pass for us to study it in this class:

--- a/src/planes.typ
+++ b/src/planes.typ
@@ -28,7 +28,7 @@ is perpendicular to that plane.
 )
 
 (Note that it doesn't matter which point $P$ you pick.
-You could equally well even ignore $P$ together, imagine drawing $bf(v)$ as an arrow
+You could equally well even ignore $P$ altogether, imagine drawing $bf(v)$ as an arrow
 starting from some random point not necessarily on the plane --- like the origin ---
 and requiring that $bf(v)$ punctures the plane at a right angle.)
 

--- a/src/vectors.typ
+++ b/src/vectors.typ
@@ -68,7 +68,7 @@ Some vectors in $RR^3$ are special enough to get their own shorthand.
 
   - In two dimensions:
     $ bf(v) = vec(x,y) ==> |bf(v)| := sqrt(x^2+y^2). $
-  - If three dimensions:
+  - In three dimensions:
     $ bf(v) = vec(x,y,z) ==> |bf(v)| := sqrt(x^2+y^2+z^2). $
 
   In $n$ dimensions, if $bf(v) = chevron.l a_1, ..., a_n chevron.r$,
@@ -181,7 +181,8 @@ than just using the slope of the blue ray.
 
 If $bf(v)_1 = vec(x_1, y_1)$ and $bf(v)_2 = vec(x_2, y_2)$ are vectors,
 drawn as arrows with a common starting point,
-then their sum $bf(v)_1 + bf(v)_2$ makes a parallelogram in the plane with $bf(0)$
+then $bf(v)_1$, $bf(v)_2$, and their sum $bf(v)_1 + bf(v)_2$
+make a parallelogram in the plane together with $bf(0)$,
 as shown in @fig-parallelogram.
 
 #figure(


### PR DESCRIPTION
Closes #50.

Proofread all four chapters in Part Alfa (`src/vectors.typ`, `src/dot.typ`, `src/planes.typ`, `src/cross.typ`). All mathematical content (lengths, directions/unit vectors, determinant/area/volume formulas, dot product angle and projection examples, plane distance formulas, cross product formulas, and sample problem answers) was verified by hand and found correct — no math errors to flag.

Fixed 6 minor typos/grammar issues:
- `vectors.typ`: "If three dimensions" → "In three dimensions" (parallel structure)
- `vectors.typ`: clarified incomplete sentence describing the parallelogram formed by two vectors and their sum
- `dot.typ`: missing "of" — "some sort 'algebraic' side" → "some sort of 'algebraic' side"
- `planes.typ`: "ignore $P$ together" → "ignore $P$ altogether"
- `cross.typ`: duplicated word "to to the area" → "to the area"
- `cross.typ`: summary table used `bf(a)`/`bf(b)` instead of `bf(v)`/`bf(w)` for the cross product row, inconsistent with the rest of the chapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zo1gHKDMuzZb4x14n6uu2

---
_Generated by [Claude Code](https://claude.ai/code/session_015zo1gHKDMuzZb4x14n6uu2)_