### PR TITLE
fix: Proofread Part Charlie (complex numbers)

### DIFF
--- a/src/complex.typ
+++ b/src/complex.typ
@@ -24,7 +24,7 @@ $CC$ is just an elaborate $RR^2$ cosplay*.
 )
 
 At the start of the course, I warned you about type safety, and
-I repeatedly stressed you that you *cannot multiply two vectors in $RR^n$ to get another vector*.
+I repeatedly stressed to you that you *cannot multiply two vectors in $RR^n$ to get another vector*.
 (You had a "dot product", but it spits out a number.
 Honestly, you shouldn't think of dot product as a "product"; the name sucks.)
 
@@ -95,7 +95,7 @@ Here's a simple example.
     &= 100 + 240 i + 105 i + 252 i^2 \
     &= 100 + 345 i + 252 (- 1) quad ("since " i^2 = - 1) \
     &= 100 + 345 i - 252 = (100 - 252) + 345 i = - 152 + 345 i. $
-  The above theorem is promising that if we had used polar form,
+  The above theorem is promising that if we use polar form,
   the _angles_ will add and the _magnitudes_ will multiply.
   Let's verify this holds up.
 
@@ -156,7 +156,7 @@ that you would not expect to be true.
 
 Let's start with _magnitudes_.
 If you don't trust your teacher (a good instinct to have sometimes 😉)
-you might not _believe_ me the magnitudes multiply.
+you might not _believe_ me that the magnitudes multiply.
 Because let's say $z_1 = a + b i$ and $z_2 = c + d i$.
 Then
 $ z_1 z_2 = (a + b i)(c + d i) = (a c - b d) + (a d + b c) i $


### PR DESCRIPTION
Closes #54.

Proofread `src/complex.typ` and `src/mt1.typ` (Part Charlie: Review of complex numbers). All worked examples and exercises (polar-form arithmetic, De Moivre's theorem examples, $n$th-root computations, the Brahmagupta-Fibonacci identity derivation, trig addition/double-angle derivations) were checked by hand and the math was correct throughout. Only grammar issues were found and fixed:

- "I repeatedly stressed you that you *cannot multiply...*" → "I repeatedly stressed **to** you that..." (missing preposition)
- "The above theorem is promising that if we **had used** polar form, the angles *will* add..." → "...if we **use** polar form..." (tense mismatch with the following "will add"/"will multiply")
- "you might not believe me the magnitudes multiply" → "...believe me **that** the magnitudes multiply" (missing conjunction)

No mathematical errors were found, so no review comments are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkCYFECJ8AknXNCWitMtMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkCYFECJ8AknXNCWitMtMT)_