### PR TITLE
fix: proofread solutions for Part Charlie

### DIFF
--- a/src/sol-charlie.typ
+++ b/src/sol-charlie.typ
@@ -248,7 +248,7 @@ So $bf(b)_1 pm bf(b)_2$ are eigenvectors with eigenvalues $pm 1$.
 Since $M$ is a $2 times 2$ matrix there are at most two eigenvalues: we found them all!
 
 The trace of $M$ is the sum of the eigenvalues.
-This gives the trace $1 + (-1) = 0$.
+Call in the answer $1 + (-1) = 0$.
 
 #h3[Fourth approach: Change coordinates]
 

--- a/src/sol-charlie.typ
+++ b/src/sol-charlie.typ
@@ -22,7 +22,7 @@ That is, the complex arguments of $1+i$, $2+i$, $3+i$
 are $arctan 1/1$, $arctan 1/2$, and $arctan 1/3$ respectively,
 and the argument $z$ will hence be the sum of those three acute angles.
 
-However, we can can compute $z$ by direct multiplication:
+However, we can compute $z$ by direct multiplication:
 $ z = (1+i)(2+i)(3+i) = (1+3i)(3+i) = 10i. $
 Because this number is pure imaginary its argument is $90 degree$ as needed.
 
@@ -81,19 +81,19 @@ $ bf(a) = vec(4-7/2, 5-7/2, 6-2(7/2)) = vec(1/2, 3/2, -1). $
 $ 1/6 |arrow(D A) dot (arrow(D B) times arrow(D C))|. $
 equals the volume of the tetrahedron $A B C D$.
 
-In general, the volume of the tetrahedron is $1/6$ the area of the
+In general, the volume of the tetrahedron is $1/6$ the volume of the
 parallelepiped formed by $arrow(D A)$, $arrow(D B)$, $arrow(D C)$.
-Se we will prove that
+So we will prove that
 $ |arrow(D A) dot (arrow(D B) times arrow(D C))| $
 gives the volume of that parallelepiped.
 Here are two approaches for proving it.
 
 #h3[First approach using coordinates]
 
-Let $D = (0,0,0)$, $A = (x_A, y_A, b_A)$, $B = (x_B, y_B, z_B)$, $C = (x_C, y_C, z_C)$.
+Let $D = (0,0,0)$, $A = (x_A, y_A, z_A)$, $B = (x_B, y_B, z_B)$, $C = (x_C, y_C, z_C)$.
 Then expanding the cross product gives
 
-$ (x_A ee_1 + y_A ee_2 + z_A bf(e_3)) dot
+$ (x_A ee_1 + y_A ee_2 + z_A ee_3) dot
   detmat(ee_1, ee_2, ee_3; x_B, y_B, z_B; x_C, y_C, z_C). $
 
 If you think about what evaluating the determinant using the formula
@@ -153,7 +153,7 @@ We know that
 $
   M(bf(b)_1) &= bf(b)_1 \
   M(bf(b)_2) &= bf(b)_2 \
-  M(bf(n)_2) &= bf(0).
+  M(bf(n)) &= bf(0).
 $
 
 If we wrote $M$ as a matrix _in this new basis_ $chevron.l bf(b)_1, bf(b)_2, bf(n) chevron.r$
@@ -165,7 +165,7 @@ which has determinant $0$.
 #remark[
   In fact, if you also know that the trace doesn't change
   when you rewrite $M$ in a different basis,
-  this approach shows the trace $M$ is always exactly $1+1+0 = 2$ as well,
+  this approach shows the trace of $M$ is always exactly $1+1+0 = 2$ as well,
   no matter which plane $cal(P)$ is picked.
 ]
 
@@ -248,7 +248,7 @@ So $bf(b)_1 pm bf(b)_2$ are eigenvectors with eigenvalues $pm 1$.
 Since $M$ is a $2 times 2$ matrix there are at most two eigenvalues: we found them all!
 
 The trace of $M$ is the sum of the eigenvalues.
-Call in the answer $1 + (-1) = 0$.
+This gives the trace $1 + (-1) = 0$.
 
 #h3[Fourth approach: Change coordinates]
 


### PR DESCRIPTION
Closes #55.

Proofread `src/sol-charlie.typ`, which contains the solutions for Part Charlie. All worked solutions (Gaussian integer factoring, arctan sum via complex argument, plane projection, tetrahedron volume via triple product, projection-matrix determinant, perpendicular cross products, matrix trace, complex cube roots) were checked by hand and the math was correct throughout. Only typos and notation slips were found and fixed:

- Duplicate word: "we can can compute" → "we can compute"
- "the area of the parallelepiped" → "the volume of the parallelepiped" (a parallelepiped's volume, not area, is what's being computed)
- "Se we will prove" → "So we will prove"
- Typo: $A = (x_A, y_A, b_A)$ → $(x_A, y_A, z_A)$
- Notation inconsistency: $z_A bf(e_3)$ → $z_A ee_3$, matching the $ee_1, ee_2, ee_3$ basis notation used throughout the rest of the section
- Typo: $M(bf(n)_2) = bf(0)$ → $M(bf(n)) = bf(0)$
- "the trace $M$" → "the trace of $M$" (missing preposition)
- Garbled sentence: "Call in the answer" → "This gives the trace"

No mathematical errors were found, so no review comments are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZnfGC4MrG2vqKXX8StW9G)_