### PR TITLE
fix: proofread solutions for Part Delta

### DIFF
--- a/src/sol-delta.typ
+++ b/src/sol-delta.typ
@@ -21,7 +21,7 @@ Thus we get
 $ L = 1/2 int_(u=-7)^7 sqrt(u^2+1) dif u. $
 Now using the hint we get that
 $ L &= 1/4 [u sqrt(u^2+1) + log(u + sqrt(u^2+1))]_(u=-7)^7 \
-  &=  1/4 (14 sqrt(50) + log(7 + sqrt(50)) - log(-7 + sqrt(50)))) \
+  &= 1/4 (14 sqrt(50) + log(7 + sqrt(50)) - log(-7 + sqrt(50))) \
   &= 35/2 sqrt(2) + 1/4 log((7 + 5 sqrt(2)) / (-7 + 5 sqrt(2))) \
   &= 35/2 sqrt(2) + 1/4 log((7 + 5 sqrt(2))^2 / ((7 + 5 sqrt(2))(-7 + 5 sqrt(2)))) \
   &= 35/2 sqrt(2) + 1/4 log((7 + 5 sqrt(2))^2) \
@@ -31,8 +31,8 @@ $ L &= 1/4 [u sqrt(u^2+1) + log(u + sqrt(u^2+1))]_(u=-7)^7 \
 
 #recall-thm(<exer-param-teacup>)
 
-We will first parametrize the motion of the toddler and then compute the
-distance traveled after one full revolution of the ride.
+We will first parametrize the motion of the toddler and then differentiate
+to find the velocity vector.
 
 1. The teacup center rotates clockwise with angular velocity
   $omega_(upright("ride"))$ in a circular path of radius $R$ around a


### PR DESCRIPTION
Closes #57.

Proofread `src/sol-delta.typ` (solutions for Part Delta). Found and fixed two small errors:

- In the parabola arc-length solution, there was an extra closing parenthesis in the line `&=  1/4 (14 sqrt(50) + log(7 + sqrt(50)) - log(-7 + sqrt(50))))` — removed the stray `)` (and a stray double space).
- The intro sentence to the teacup solution said "We will first parametrize the motion of the toddler and then compute the distance traveled after one full revolution of the ride," but the exercise only asks for the velocity vector, and no distance is ever computed in the solution. Changed to "We will first parametrize the motion of the toddler and then differentiate to find the velocity vector," matching what the solution actually does.

I independently re-derived all four solutions (parabola arc length, teacup velocity, helicopter parametrization/distance, and the coin-rotation-paradox clock answer) and verified the final boxed answers are mathematically correct. No large mathematical errors were found.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaB5NJWhBdwp68NcWrgWQx)_