### PR TITLE
fix: Proofread Part Echo (multivariable differentiation)

### DIFF
--- a/src/antigrad.typ
+++ b/src/antigrad.typ
@@ -91,7 +91,7 @@ Let's do a two-variable example first.
 
   Integrate $(partial f) / (partial x)$ and $(partial f) / (partial y)$ with respect to $x$ and $y$:
   $ f (x , y) & = int (partial f) / (partial x) dif x = int (3 x^2 + 4 x y + y^2) dif x  = x^3 + 2 x^2 y + x y^2 + C_1(y) \
-    f (x , y) & = int (partial f) / (partial y) dif y = int (2 x^2 + 2 x y - 3 y^2) dif y = 2 x^2 + x y^2 - y^3 + C_2(x). $
+    f (x , y) & = int (partial f) / (partial y) dif y = int (2 x^2 + 2 x y - 3 y^2) dif y = 2 x^2 y + x y^2 - y^3 + C_2(x). $
   Stitching this together gives
   $ f (x , y) = #boxed($ x^3 + 2 x^2 y + x y^2 - y^3 + C $). #qedhere $
 ]
@@ -217,7 +217,7 @@ So let's see some examples:
     $f_x = 7 x^6 y^3 ==>
       (partial / (partial y)) f_x = 21 x^6 y^2$.
   - Do it the other order:
-    $f_y = 3 x^6 y^2 ==>
+    $f_y = 3 x^7 y^2 ==>
       (partial / (partial x)) f_y = 21 x^6 y^2$.
   - Either way we get the same result
     $ f_(x y) = f_(y x) = 21 x^6 y^2. $

--- a/src/grad.typ
+++ b/src/grad.typ
@@ -148,7 +148,7 @@ then I'll explain why the gradient is the normal vector we need to complete our 
   nabla f_3 (x,y) = vec(2 x, 2 y), &#h(2em)
   nabla f_4 (x,y,z) = vec(1,1,1), \
   nabla f_5 (x,y,z) = vec(y+z, x+z, x+y), &#h(2em)
-  nabla f_6 (x,y) = vec(y x^(y-1), log(y) dot x^y). #qedhere
+  nabla f_6 (x,y) = vec(y x^(y-1), log(x) dot x^y). #qedhere
   $
   (Remember $log$ is the natural log, not base $10$.)
 ]
@@ -234,7 +234,7 @@ The motivating question here is:
   We'd like to take a step $0.01$ away in some direction of our choice.
   For example, we could go to $(2.99, 4)$, or $(3, 4.01)$ or $(2.992, 4.006)$,
   or any other point on the circle we've marked in the figure below.
-  (For the third point, note that $sqrt((3-2.992)^2-(4-4.006)^2) = 0.01$,
+  (For the third point, note that $sqrt((3-2.992)^2+(4-4.006)^2) = 0.01$,
   so that point is indeed $0.01$ away.)
 
   - Which way should we step if we want to maximize the $f$-value at the new point?


### PR DESCRIPTION
Closes #58.

Proofread `src/level.typ`, `src/partial.typ`, `src/grad.typ`, `src/antigrad.typ` (the files included under Part Echo). Found and fixed four small errors:

- `src/grad.typ`: in the gradient of $f_6(x,y) = x^y$, the partial derivative with respect to $y$ was written as $log(y) dot x^y$ instead of $log(x) dot x^y$, inconsistent with the correct formula derived earlier in `src/partial.typ`.
- `src/grad.typ`: in the gradient-descent example, the distance formula for the point $(2.992, 4.006)$ had a minus sign instead of a plus sign inside the square root ($sqrt((3-2.992)^2-(4-4.006)^2)$ should use `+` to compute Euclidean distance; with `+` it correctly evaluates to $0.01$).
- `src/antigrad.typ`: in the second anti-gradient example, an intermediate integration step dropped a factor of $y$ (wrote "$2 x^2$" instead of "$2 x^2 y$"), even though the final boxed answer was already correct.
- `src/antigrad.typ`: in the partial-derivatives-commute example with $f(x,y) = x^7 y^3$, $f_y$ was written as $3 x^6 y^2$ instead of $3 x^7 y^2$ (the subsequent derivative step already used the correct exponent, so only this intermediate line was wrong).

No large mathematical errors were found; `level.typ` and `partial.typ` had no issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_014qufNPbjSA9FyD3gKmnyfv)_