### PR TITLE
fix: Proofread Part Foxtrot (optimization)

### DIFF
--- a/src/minmax.typ
+++ b/src/minmax.typ
@@ -26,8 +26,8 @@ a random function $f(x) = -1/5 x^6 - 2/7 x^5 + 2/3 x^4 + x^3$.
 From left to right in @fig-1801-critical-points, there are four critical points:
 
 - A local maximum (that isn't a global maximum), drawn in blue.
-- A local minimum (that isn't a global minimum), draw in green.
-- An critical inflection point --- neither a local minimum _nor_ a local maximum. Drawn in orange.
+- A local minimum (that isn't a global minimum), drawn in green.
+- A critical inflection point --- neither a local minimum _nor_ a local maximum. Drawn in orange.
 - A global maximum, drawn in purple.
 
 Note there's no global minimum at all, since the function $f$ goes to $-oo$ in both directions
@@ -307,8 +307,8 @@ The bad news is that it's tricky. You really have to think.
     For example, if you see $x y - x = 0$, write it as $x (y-1) = 0$,
     then either $x=0$ or $y=1$.
 
-  - If you are taking square roots of both sides,
-    That is, if $a^2 = b^2$, you conclude $a = pm b$, not $a = b$.
+  - If you are taking square roots of both sides:
+    that is, if $a^2 = b^2$, you conclude $a = pm b$, not $a = b$.
 
   - Be careful in making sure you don't miss cases if you start getting OR statements.
     In the last example, there were $2^2 = 4$ cases.
@@ -410,7 +410,7 @@ The exam ones will probably tone down this algebra step a bit.
     $ y &= z + 2 \ x &= 2 y - z. $
     Our strategy now is to write everything in terms of $z$.
     The first equation tells us $y = z+2$, so the second equation says
-    $ x = 2(z+2) + z = z + 4. $
+    $ x = 2(z+2) - z = z + 4. $
     We have one more equation, so we make the two substitutions everywhere and expand:
     $ 0 &= (z+2)((z+4)-(z+2)) -2((z+4)-(z+2))z -2(z+4) \
       &= 2(z+2) - 4z - 2(z+4) = -4z - 4 \

--- a/src/opt.typ
+++ b/src/opt.typ
@@ -338,7 +338,7 @@ Here's an example where a good idea is to kill $lambda$ ASAP:
       $ f(x,y) approx 3/4  x^2 + (x / 2 + y)^2 = 3/4 y^2 + (x + y / 2)^2 $
       for large $x$ and $y$.
       The first expression shows that if $x$ is big, then so is $f$;
-      The first expression shows that if $y$ is big, then so is $f$.
+      the second expression shows that if $y$ is big, then so is $f$.
     ]
 
   In conclusion, the global minimum is $f(1/3, 4/3) = 11/3$.
@@ -354,7 +354,7 @@ And here's an example where we kill every variable _except_ $lambda$:
 #soln[
   We want to minimize the function
   $f (x , y , z) = x^2 + y^2 + z^2 + y - z$ subject to the constraint
-  $  (x , y , z) = x + 2 y + 3 z = 4$.
+  $ g (x , y , z) = x + 2 y + 3 z = 4$.
 
   0. The $g = 4$ region is a plane with no boundary but
     limit cases if any variable becomes $pm oo$.
@@ -505,9 +505,9 @@ because of the amount of arithmetic required; it's here just to illustrate.
     Since $169 = 13^2$ is a square, this could be written more simply as
     $ x = pm 1 / sqrt(13) , quad y = pm 3 / sqrt(13) , quad z = pm 4 / sqrt(13) . $
   / Case 8 where $x = 0$, $y = 0$, $z = 0$:
-    This doesn't yield a valid solution because it doesn't like on the constraint $x^4+y^4+z^4=2$.
+    This doesn't yield a valid solution because it doesn't lie on the constraint $x^4+y^4+z^4=2$.
 
-  Hence there are a whopping total of $26$ LM-critical points.
+  Hence there are a whopping total of $14$ LM-critical points.
   They are:
   - $x = 0$, $y = 0$, $z = pm root(4, 2)$,
   - $x = 0$, $y = pm root(4, 2)$, $z = 0$,
@@ -520,7 +520,7 @@ because of the amount of arithmetic required; it's here just to illustrate.
   When searching for the maximum, we should always take $+$ for $pm$ to maximize $f(x,y,z)$;
   similarly, the minimum uses only $-$ for $pm$.
   Note also that plugging in all $-$'s is the negative of plugging in all $+$'s.
-  So this reduces us from $26$ cases to just $7$.
+  So this reduces us from $14$ cases to just $7$.
   If we actually try all seven, we find that the last one is the optimal one;
   that is, the maximum and minimums are
   $ f(1/sqrt(13), 3/sqrt(13), 4/sqrt(13)) &= 2sqrt(13) \

--- a/src/regions.typ
+++ b/src/regions.typ
@@ -69,7 +69,7 @@ We provide several examples.
   In $RR^2$, some one-dimensional regions:
   - The unit circle $x^2 + y^2 = 1$, which is a circle of radius $1$, not filled.
   - Both $x^2+y^2=1$ and $x,y > 0$, a quarter-arc, not including $(1,0)$ and $(0,1)$.
-  - Both $x^2+y^2=1$ and $x,y >= 0$, a quarter-arc, including $(1,0)$ and $(0,1$).
+  - Both $x^2+y^2=1$ and $x,y >= 0$, a quarter-arc, including $(1,0)$ and $(0,1)$.
   - The equation $x + y = 1$ is a line.
   - Both $x + y = 1$ and $x,y > 0$: a line segment not containing the endpoints $(1,0)$ and $(0,1)$.
   - Both $x + y = 1$ and $x,y >= 0$: a line segment containing the endpoints $(1,0)$ and $(0,1)$.
@@ -95,7 +95,7 @@ The three that you should care about for this class are the following:
   constraints and turn it into an $=$ constraint.
   For example, the boundary of the region cut out by $-1 <= x <= 1$ and $-1 <= y <= 1$
   (which is a square of side length $2$)
-  are the four sides of the square, where either $x = pm 1$ or $y = pm 1$.
+  is the four sides of the square, where either $x = pm 1$ or $y = pm 1$.
 
 - The *limit cases* come in two forms:
   - If any of the variables can go to $pm oo$, all those cases are usually limit cases.
@@ -216,7 +216,7 @@ See @table-1d-regions, @table-2d-regions, @table-3d-regions.
     [$x^2 + y^2 + z^2 < 1$], [3D], [No boundary], [$x^2 + y^2 + z^2 -> 1^-$],
     [$x^2 + y^2 + z^2 <= 1$], [3D], [$x^2 + y^2 + z^2 = 1$], [No limit cases],
     [$x^2 + y^2 + z^2 = 1$], [2D], [No boundary], [No limit cases],
-    [$x^2 + y^2 + z^2 = 1 \ x,y,z > 0$], [2D], [No boundary], [$(1,0)$ and $(0,1)$],
+    [$x^2 + y^2 + z^2 = 1 \ x,y,z > 0$], [2D], [No boundary], [$x -> 0^+$ or $y -> 0^+$ or $z -> 0^+$],
     [$x^2 + y^2 + z^2 = 1 \ x,y,z >= 0$], [2D], [Three quarter-circle arcs#footnote[
       To be explicit, the first quarter circle is $x^2+y^2=1$, $x,y >=0$ and $z = 0$.
       The other two quarter-circle arcs are similar.


### PR DESCRIPTION
Closes #60.

Proofread `src/minmax.typ`, `src/regions.typ`, `src/opt.typ`, `src/mt2.typ` (the files included under Part Foxtrot). Found and fixed:

- `src/minmax.typ`: "draw in green" → "drawn in green", and "An critical inflection point" → "A critical inflection point", to match the parallel "drawn in ..." bullet list.
- `src/minmax.typ`: broken punctuation in the "taking square roots of both sides, That is, ..." tip, joined into one sentence.
- `src/minmax.typ`: in the critical-points sample for $f(x,y,z) = z(x-y)(y-z) - 2xz$, a sign flip in the substitution step "$x = 2(z+2) + z = z+4$" (should be "$- z$"); the final answer $z+4$ was already correct, only the intermediate algebra step was wrong.
- `src/regions.typ`: stray `$` placement in "$(1,0)$ and $(0,1$)." → "$(0,1)$".
- `src/regions.typ`: subject-verb agreement, "the boundary ... are the four sides" → "is the four sides".
- `src/regions.typ`: in the 3D regions table, the limit-cases entry for $x^2+y^2+z^2=1$, $x,y,z>0$ incorrectly listed boundary-style points "$(1,0)$ and $(0,1)$" (which aren't even valid 3-variable points); replaced with the correct limit cases "$x \to 0^+$ or $y \to 0^+$ or $z \to 0^+$", consistent with the analogous row in the 2D table.
- `src/opt.typ`: missing "$g$" in "$ (x,y,z) = x+2y+3z=4$" (the constraint function), should be "$g(x,y,z) = ...$".
- `src/opt.typ`: duplicated "The first expression" in a footnote where the second sentence should refer to "the second expression".
- `src/opt.typ`: "doesn't like on the constraint" → "doesn't lie on the constraint".
- `src/opt.typ`: in the $x^3+3y^3+4z^3$ Lagrange multiplier example, the total LM-critical point count was miscounted as 26; since the per-case sign choices are tied together by ratios like $z = 4x$ (not independent), the correct total is 14, not 26. This is also confirmed by the next sentence, which says the count "reduces ... to just 7" by halving via the ±-symmetry ($14/2 = 7$, but $26/2 = 13$ would be inconsistent).

No large mathematical errors were found beyond the miscounted LM-critical points above; `src/mt2.typ` (the practice midterm problem statements) had no issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnJnjJdFpjW9nJ1BfZGXo1)_