### PR TITLE
fix: Proofread Part Golf (2D integrals of scalar functions)

### DIFF
--- a/src/chvar.typ
+++ b/src/chvar.typ
@@ -151,7 +151,7 @@ $ J_(bf(T)) = mat(
   $ partial / (partial u) sqrt(u v) &= 1/2 u^(-1/2) v^(1/2) \
     partial / (partial v) sqrt(u v) &= 1/2 u^(1/2) v^(-1/2). $
   So the Jacobian matrix for $bf(T)$ is
-  $ J_(bf(T)) = mat(1/2 u^(-3/2) v^(1/2), 1/2 u^(-1/2) v^(-1/2);
+  $ J_(bf(T)) = mat(-1/2 u^(-3/2) v^(1/2), 1/2 u^(-1/2) v^(-1/2);
      1/2 u^(-1/2) v^(1/2), 1/2 u^(1/2) v^(-1/2)). $
 ]
 #example[
@@ -303,7 +303,7 @@ Let's see an example of how to carry out this integration.
       [$ x = r cos theta \ y = r sin theta $],
       [$ u = y slash x \ v = x y $],
     [Example Jacobian matrix],
-      [$ mat(cos theta, sin theta; - r sin theta, r cos theta) $],
+      [$ mat(cos theta, -r sin theta; sin theta, r cos theta) $],
       [$ mat(-y slash x^2, 1 slash x; y, x) $],
     [Example Jacobian determinant],
       [$ r $],
@@ -394,7 +394,7 @@ It's a tiny optimization, but it's worth pointing out.
   Look for the common pattern
   $ int_(u="number")^("number") int_(v="number")^("number")
     f(u) g(v) dif v dif u
-    = (int_(u="number")^("number") f(u) v dif u)
+    = (int_(u="number")^("number") f(u) dif u)
       ( int_(v="number")^("number") g(v) dif v). $
 ]
 Remember, this doesn't work if either the integrand doesn't factor,

--- a/src/double.typ
+++ b/src/double.typ
@@ -6,7 +6,7 @@ One common theme from 18.02 that you might have noticed in part Foxtrot is that,
 unlike in 18.01 where you were hyper-focused on the function $f$ you were optimizing,
 in 18.02 the _region_ you're working with deserves a lot of attention.
 This will be true for the material in this chapter too ---
-you ought to paying most attention to the region
+you ought to pay most attention to the region
 before you even look at the function $f$ that's being integrated.
 
 == [RECIPE] Integrating over rectangles
@@ -82,7 +82,7 @@ Here's another example.
     $x$ out of the integral: $ x int_(y=0)^1 cos (x y) dif y . $
 
     Now, we compute $int_(y=0)^1 cos (x y) dif y$.
-    $ int_(y=0)^1 cos (x y) dif u = [1/x sin (x y)]_0^1 = sin(x) / x. $
+    $ int_(y=0)^1 cos (x y) dif y = [1/x sin (x y)]_0^1 = sin(x) / x. $
 
     Thus, the result of the inner integral is:
     $ x dot sin(x) / x = sin (x) . $
@@ -584,21 +584,21 @@ Put in recipe form:
   and the region can be rewritten to
   $ cal(R) = cases(0 <= y <= 1, 0 <= x <= 2 y). $
   Turning this _back_ into a double integral gives
-  $ int_(y=0)^1 int_(x=0)^(2y) e^(y^2) dif y dif x. $
+  $ int_(y=0)^1 int_(x=0)^(2y) e^(y^2) dif x dif y. $
 
   The inner integral is with respect to $x$,
   but the integrand $e^(y^2)$ is independent of $x$.
   Therefore, the inner integral becomes:
   $ int_(x = 0)^(2 y) e^(y^2) dif x = 2 y dot e^(y^2) . $
   Thus, it remains to calculate
-  $ int_(y=0)^1 (2 y dot e^(y^2)) dif y dif x. $
+  $ int_(y=0)^1 (2 y dot e^(y^2)) dif y. $
 
   And now things are different: $2 y dot e^(y^2)$ _does_ have a valid anti-derivative.
   If you use the 18.01 method or even just are good at guessing,
   you can find the indefinite 18.01 integral
   $ int 2 y e^(y^2) dif y = e^(y^2) + C. $
   So the final answer to the problem is
-  $ int_(y=0)^1 2y e^(y^2) dif y dif x = lr([e^(y^2)])_(y=0)^(y=1) = #boxed[$ e-1 $]. #qedhere $
+  $ int_(y=0)^1 2y e^(y^2) dif y = lr([e^(y^2)])_(y=0)^(y=1) = #boxed[$ e-1 $]. #qedhere $
 ]
 
 #sample[

--- a/src/ipep.typ
+++ b/src/ipep.typ
@@ -62,7 +62,7 @@ Here's a rundown of the things in the chart.
   You also have a function $f : RR^n -> RR$.
   The line integral lets you add up the values of $f$ along the trajectory.
 
-  This is just turns out to be a _single_ 18.01 integral.
+  This just turns out to be a _single_ 18.01 integral.
   Usually your path is parametrized by a single variable $t$.
   So even though the expression inside the integral
   $ int_(t_0)^(t_1) f(bf(r(t))) |bf(r)'(t)| dif t $
@@ -86,7 +86,7 @@ Here's a rundown of the things in the chart.
 
   But like the line integral, after you work out the parametrization stuff,
   the surface integral will transform into a $2$-variable area integral.
-  In other words *surface integrals translate directly into area integral*.
+  In other words *surface integrals translate directly into area integrals*.
 
 So the bottom trio --- 2D/3D line integral and surface integral ---
 end up being special instances of the single and double integrals.

--- a/src/polar.typ
+++ b/src/polar.typ
@@ -171,7 +171,7 @@ Here's an example of what that could look like.
   we're practically forced to use polar coordinates.
   Indeed, the right way to think of the region we're integrating over is that it consists of
   $ 0 <= y <= 3 " and " x^2 + y^2 <= 9 $
-  which is just the upper half a circle of radius $3$.
+  which is just the upper half of a circle of radius $3$.
   So using polar coordinates is just obviously the right thing to do,
   because the limits of integration are amazing:
   - The region is defined by $0 <= r <= 3$ and $0 <= theta <= pi$.


### PR DESCRIPTION
Closes #62.

Proofread `src/ipep.typ`, `src/double.typ`, `src/chvar.typ`, `src/polar.typ`, `src/shorthand.typ` (the files included under Part Golf). Found and fixed:

- `ipep.typ`: "This is just turns out to be" → "This just turns out to be" (dropped stray "is"); "surface integrals translate directly into area integral" → "... area integrals" to match the parallel plural phrasing used for line integrals just above.
- `double.typ`: "you ought to paying most attention" → "ought to pay" (modal verb needs bare infinitive); a worked example wrote `int cos(xy) dif u` instead of `dif y` (wrong differential variable); a later worked example had the `dif x`/`dif y` ordering backwards relative to the book's established convention (outer integral sign first, differentials in `dif(inner) dif(outer)` order), and kept a spurious leftover `dif x` in two more places after the `x`-integral had already been evaluated out.
- `chvar.typ`: a Jacobian matrix entry was missing a minus sign (the same partial derivative was correctly computed with a minus sign two lines earlier in the same example); a comparison table displayed the polar Jacobian matrix transposed relative to the convention (and the correctly-derived version) used earlier in the same file — entries (1,2) and (2,1) were swapped; a stray extra `v` appeared in the general formula for factoring integrals over rectangles.
- `polar.typ`: "upper half a circle" → "upper half of a circle" (missing preposition).

No large mathematical errors were found; all of the worked numerical examples (the change-of-variables area computations, the offset-circle polar integral, the `(x^2+y^2)^(5/2)` and `1/(x^2+y^2+17)` polar integrals, and the quarter-disk center of mass) check out correctly by independent re-derivation. `shorthand.typ` had no issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUwMVz82Rfm5vp1xsMDNq9)_