### PR TITLE
fix: Proofread Part Hotel (3D integrals of scalar functions)

### DIFF
--- a/src/psurf.typ
+++ b/src/psurf.typ
@@ -83,7 +83,7 @@ a parametrization that uses a rectangular sheet of paper.
   ],
   caption: [
     Consider a unit sphere; then the parametrization
-    $bf(r) (phi, theta) = (sin phi cos theta , phi sin theta , cos phi)$
+    $bf(r) (phi, theta) = (sin phi cos theta , sin phi sin theta , cos phi)$
     corresponds to longitude and latitude.
     In this cartoon, one should imagine the yellow sheet of paper being a map of the Earth,
     drawn in green.

--- a/src/sph.typ
+++ b/src/sph.typ
@@ -242,8 +242,8 @@ This is actually a bit easier to see than the last case.
 / Algebraic proof (easier):
   We need to verify that the $x$, $y$, $z$ coordinates on both sides are the same:
   $
-    rho sin(-phi) cos theta &= rho sin phi cos (theta pm phi) \
-    rho sin(-phi) sin theta &= rho sin phi sin (theta pm phi) \
+    rho sin(-phi) cos theta &= rho sin phi cos (theta pm pi) \
+    rho sin(-phi) sin theta &= rho sin phi sin (theta pm pi) \
     rho cos (-phi) &= rho cos phi.
   $
   But $sin(-phi) = -sin(phi)$, $cos(theta pm pi) = -cos theta$,
@@ -342,7 +342,7 @@ It's actually pretty much exactly the same.
     Let $P$ be a point on the surface of the sphere.
     Like before, we have
     $ angle P = 90 degree, quad O A = 2, quad "and" angle A O P = phi. $
-    So the surface of the sphere are those points for which $rho = 2 cos phi$.
+    So the surface of the sphere is those points for which $rho = 2 cos phi$.
     And the points _inside_ the ball are $0 <= rho <= 2 cos phi$, accordingly.
 
   / Algebraic approach:
@@ -364,7 +364,7 @@ It's actually pretty much exactly the same.
       <==> 0 &<= rho <= 2 cos phi. $
     In particular this requires $cos phi >= 0$ i.e. $phi <= pi/2$.
 
-  In conclusion, the answer is $cal(R)$ in polar coordinates is exactly
+  In conclusion, the answer is that $cal(T)$ in spherical coordinates is exactly
   $ #boxed[$ 0 <= theta < 2 pi " and " 0 <= phi <= pi/2 " and " rho <= 2 cos phi $]. #qedhere $
 ]
 

--- a/src/surfcross.typ
+++ b/src/surfcross.typ
@@ -110,7 +110,7 @@ The parametrization we expect to use is
 $ bf(r)(x,y) = vec(x, y, f(x,y)). $
 The partial derivatives are
 $ frac(partial bf(r), partial x)
-  &= vec((partial x) / (partial x) , (partial z) / (partial x) , (partial z) / (partial x))
+  &= vec((partial x) / (partial x) , (partial y) / (partial x) , (partial z) / (partial x))
   = vec(1 , 0 , (partial z) / (partial x) ) \
   frac(partial bf(r), partial y)
   &= vec((partial x) / (partial y) , (partial y) / (partial y) , (partial z) / (partial y))

--- a/src/triple.typ
+++ b/src/triple.typ
@@ -257,7 +257,7 @@ Note that, as I said, we could have given this example _before_ this section.
   Gravitational force is a vector.
 ]
 
-Suppose a point of mass $m$ is located at the origin $O = (0,0,0)$,
+Suppose a point of mass $m$ is located at the origin $O = (0,0,0)$.
 In general, given a mass $m$ at a point $O$ and a point of mass $M$ at a point $P$,
 Newton's law says the gravitational force exerted by $P$ on $O$ is
 $ bf(F)_("gravity") = (G dot m dot M)


### PR DESCRIPTION
Closes #64.

Proofread the five files of Part Hotel (`src/triple.typ`, `src/sph.typ`, `src/psurf.typ`, `src/scalint.typ`, `src/surfcross.typ`). Found and fixed the following small issues:

- `src/triple.typ`: comma splice fixed to a period before "In general, given a mass $m$ at a point $O$..." in the gravity section.
- `src/sph.typ`: in the algebraic proof of the "illegal angle less than zero" case, the equations used $theta pm phi$ where they should use $theta pm pi$ (the explanation immediately below already correctly refers to $theta pm pi$, so this was an inconsistency).
- `src/sph.typ`: "the surface of the sphere are those points" → "is those points" (subject-verb agreement).
- `src/sph.typ`: the conclusion of the offset-sphere example called the region $cal(R)$ (should be $cal(T)$, matching the rest of the example) and "polar coordinates" (should be "spherical coordinates", since the answer is given in terms of $rho, phi, theta$).
- `src/psurf.typ`: the figure caption for the spherical-Earth parametrization dropped a factor of $sin phi$ in the $y$-component, writing $(sin phi cos theta, phi sin theta, cos phi)$ instead of $(sin phi cos theta, sin phi sin theta, cos phi)$ as defined just above.
- `src/surfcross.typ`: in deriving the magic cross-product formula for graphs, the middle component of $partial bf(r)/partial x$ was written as $partial z/partial x$ twice instead of $partial y/partial x$ then $partial z/partial x$.

No large mathematical errors were found; `src/scalint.typ` checked out with no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018he4c7hPD9dcMcMecaxnuJ)_