### PR TITLE
fix: proofread solutions for Part Hotel

### DIFF
--- a/src/sol-hotel.typ
+++ b/src/sol-hotel.typ
@@ -10,7 +10,7 @@ This is a famous exercise with its own page on Wikipedia at #url("https://w.wiki
 We give one solution using spherical coordinates below,
 but this is far from the only possible solution.
 
-Using cylindrical coordinates the equation of the sphere is: $ x^2 + y^2 + z^2 = R^2 . $
+Using cylindrical coordinates the equation of the sphere is: $ r^2 + z^2 = R^2 . $
 Since the hole is along the $z$-axis with radius $a$,
 we impose $ a <= r <= R $
 that is, the bead consists of those points whose distance from the $z$-axis is at least $a$.
@@ -68,7 +68,7 @@ $ sin^2 phi &= (1 - cos(2 phi))/2 \
   ==> int sin^2 phi dif phi &= phi / 2 - sin(2 phi) / 4. $
 Hence,
 $ iiint_(cal(T)) d(P) dif V
-  &= int_(theta=0)^(2 pi) dif theta int_(phi=0)^pi sin^2 phi dif phi int_(r=0)^1 r^3 dif r
+  &= int_(theta=0)^(2 pi) dif theta int_(phi=0)^pi sin^2 phi dif phi int_(r=0)^1 r^3 dif r \
   &= (2 pi) dot (pi / 2) dot (1/4) \
   &= pi^2 / 4. $
 So the final answer is
@@ -84,7 +84,7 @@ We orient the hemisphere so it rests on the $x y$-plane with the point $P$ at $(
 Then this is basically the same as the example in @sec-sph-gravity,
 except the bounds of integration change.
 
-To be precise, we have $G_1 = G_2 = 0$, and @eqn-sph-G3 and again
+To be precise, we have $G_1 = G_2 = 0$, and @eqn-sph-G3 just says
 $ G_3 = G m iiint_(cal(T)) sin phi cos phi dif rho dif phi dif theta $
 after setting the density to $1$.
 The only change is the bounds of integration: for the hemisphere we should have
@@ -205,7 +205,7 @@ Hence, the cross product is given by
 $frac(partial bf(r), partial x) times frac(partial bf(r), partial y)$:
 $ frac(partial bf(r), partial x) times frac(partial bf(r), partial y)
   &= (0 dot 2 y - 1 dot 2 x) ee_1 - (1 dot 2 y - 0 dot 2 x) ee_2 + (1 dot 1 - 0 dot 0) ee_3 \
-  &= vec(-2x, 2y, 1). $
+  &= vec(-2x, -2y, 1). $
 Hence the magnitude of this cross product is:
 $ lr(|frac(partial bf(r), partial x) times frac(partial bf(r), partial y)|) = sqrt((- 2 x)^2 + (- 2 y)^2 + (1)^2) = sqrt(4 x^2 + 4 y^2 + 1). $
 


### PR DESCRIPTION
Closes #65.

Proofread `src/sol-hotel.typ` (solutions for Part Hotel). Found and fixed:

- **Napkin-ring solution**: the sphere equation was introduced as "using cylindrical coordinates" but was written in Cartesian form, `x^2+y^2+z^2=R^2`. Corrected to `r^2+z^2=R^2`, consistent with the cylindrical-coordinate bounds (`a<=r<=R`, `r^2+z^2<=R^2`) used immediately afterward.
- **Average distance of sphere to line solution**: a missing line break (`\`) in a multi-line equation caused two separate equation rows to be merged onto the same line.
- **Gravity on hemisphere solution**: "and @eqn-sph-G3 **and again**" is a corrupted copy of the phrasing "and @eqn-sph-G3 **just says**" used in the analogous example this solution mirrors in `src/sph.typ` (@sec-sph-gravity).
- **Paraboloid surface-area solution**: the displayed cross product `vec(-2x, 2y, 1)` had a sign error in the $y$-component. The determinant expansion directly above it gives a $y$-component of $-2y$, and the magnitude computed on the very next line already correctly squares $(-2y)^2$ — only the displayed vector itself had the wrong sign. This did not affect the final boxed answer, since the sign disappears under squaring.

No large mathematical errors were found; the napkin-ring, sphere-line-distance, hemisphere-gravity, parametrized-surface (`exer-psurf`, `exer-surf-tangent`), and Archimedes hat-box-theorem solutions were all independently re-derived and check out correctly.

## Test plan
- Installed `typst` 0.15.0 and the `@local/evan:1.0.0` package plus required `@preview` deps (`gentle-clues`, `linguify`), then ran `typst compile lamv.typ` end-to-end (with placeholder SVGs standing in for Asymptote figures, since `asy` isn't available in this environment) — compiles cleanly with no errors.
- Ran `codespell` on the file — no issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhTkuZP6KAGaumueKWZexB)_