### PR TITLE
fix: Proofread Part India (line integrals of vector fields)

### DIFF
--- a/src/2dflux.typ
+++ b/src/2dflux.typ
@@ -227,8 +227,8 @@ For each example, we actually show how to do it "manually"
     So the dot product inside the integrand is
     $ (bf(F) "rotated" 90 degree "counterclockwise") dot bf(r)'(t)
       &= vec(-q, p) dot bf(r)'(t) \
-      &= vec(cos(t)^2, sin(t)^2) dot vec(-sin(t), cos(t)) \
-      &= cos^2 t dot cos t - sin^2 t dot (- sin t) = cos^3 t + sin^3 t. $
+      &= vec(-sin(t)^2, cos(t)^2) dot vec(-sin(t), cos(t)) \
+      &= sin^2 t dot sin t + cos^2 t dot cos t = sin^3 t + cos^3 t = cos^3 t + sin^3 t. $
     Hence
     $ "Flux" = int_(t = 0)^(t = 2 pi) (cos^3 t + sin^3 t) dif t . $
     It's possible to observe from here again that the integral is symmetric;

--- a/src/ftcgreen.typ
+++ b/src/ftcgreen.typ
@@ -102,10 +102,10 @@ Of course, we do this knowing that the two answers better be equal (to $-2$).
     &= (2 cos t + 1) (- sin t) + (3 sin t) (cos t) \
     &= - 2 cos t sin t - sin t + 3 sin t cos t = cos t sin t - sin t $
 
-  Integrate with respect to $t$ from $0$ to $pi/2$:
+  Integrate with respect to $t$ from $0$ to $pi$:
   $ int_(t=0)^(pi) (cos t sin t - sin t) dif t
     = int_(t=0)^(pi) (sin(2t)/2 - sin t) dif t
-    = lr([-cos(2t) - cos(t)])_(t=0)^pi = -2. $
+    = lr([-cos(2t)/4 + cos(t)])_(t=0)^pi = -2. $
 
 - Work on the brown line segment,
   parametrized again as $bf(r) (t) = (1 -  2 t, 0)$, where $t in [0, 1]$,
@@ -142,7 +142,7 @@ Of course, we do this knowing that the two answers better be equal (to $-2$).
   In general, the vector field encoded by $c dif x$ for any constant $c$ is conservative
   with potential function $f(x,y) = c x$.
   Hence, $int_(cal(C)) c dif x = c int_(cal(C)) dif x$
-  will always just equal to $c$ times the total change in $x$.
+  will always just equal $c$ times the total change in $x$.
 ]
 
 == [TEXT] Okay, but how do you tell whether $bf(F)$ is conservative?

--- a/src/vecfield.typ
+++ b/src/vecfield.typ
@@ -76,7 +76,7 @@ Let's put these examples into aquatic terms.
   If you do this, you can define a "downstream function" $f : RR^3 -> RR$ as follows:
   for every point $P$ in the river, $f(P)$ measures how far downstream you are.
   For example, if the river had a head, maybe we could assign $f$ the value zero there,
-  and then $f$ would increase as you get farther from the bank,
+  and then $f$ would increase as you get farther from the head,
   reaching the largest value at the mouth.
   (For mountainous rivers, $f$ might instead be thought of as decreasing in elevation.)
 
@@ -94,7 +94,7 @@ Let's put these examples into aquatic terms.
 
 #example(title: [Example of a non-conservative vector field: a whirlpool])[
   Now imagine instead you have a whirlpool.
-  If you throw a ball in it, it goes in circles around vertex of the whirlpool.
+  If you throw a ball in it, it goes in circles around the vortex of the whirlpool.
   This doesn't look anything like the river!
   If you have a river, you never expect a ball to come back to the same point after a while,
   because it's trying to go downstream.
@@ -257,7 +257,7 @@ a way to take one type of function and use it to build another function.
 
 For example, the gradient $nabla$ is the one we've discussed:
 if you start with a scalar-valued function $f : RR^n -> RR$,
-the gradient creates into a vector field $nabla f : RR^n -> RR^n$.
+the gradient creates a vector field $nabla f : RR^n -> RR^n$.
 (The $(dif f) / (dif x)$ in the $f : RR^1 -> RR$ case is also just the gradient,
 though a bit more degenerate.)
 
@@ -273,8 +273,8 @@ All the red arrows have two important properties I will tell you _right now_.
 Because I haven't talked much about any of the red arrows yet,
 *you won't be able to understand what this means yet*.
 That's okay.
-We'll go over what this means for each individual red arrow means when we get to it.
-However, I want tell you _in advance_ that every time we meet a red arrow,
+We'll go over what this means for each individual red arrow when we get to it.
+However, I want to tell you _in advance_ that every time we meet a red arrow,
 there will be a case of Stokes' theorem that applies to it.
 
 #memo(title: [Memorize: Two red arrows gives zero])[

--- a/src/work.typ
+++ b/src/work.typ
@@ -258,7 +258,7 @@ Let's show some examples of how to calculate this in practice.
     Differentiate $bf(r) (t)$ with respect to $t$:
     $ bf(r)' (t) = vec(- 2 , 0) . $
     Meanwhile, the parameterization into the vector field is:
-    $ bf(F) (bf(r) (t)) = bf(F) (0, 1 - 2t) = vec(0, 3 - 6t). $
+    $ bf(F) (bf(r) (t)) = bf(F) (1 - 2t, 0) = vec(0, 3 - 6t). $
     The dot product is identically equal to zero:
     $ vec(-2, 0) dot vec(0, 3-6t) = 0. $
     So the line integral is $#boxed[$0$]$ as well. #qedhere
@@ -272,7 +272,7 @@ for which work integrals are path-independent.
 
 == [TEXT] Even more shorthand: $p dif x + q dif y$
 
-Then notation $int_(cal(C)) bf(F) dot dif bf(r)$ can _still_ be contracted further:
+The notation $int_(cal(C)) bf(F) dot dif bf(r)$ can _still_ be contracted further:
 there is another shorthand that hides both $bf(F)$ and $bf(r)$ altogether.
 Here it is:
 


### PR DESCRIPTION
Closes #66.

Proofread all the `src/*.typ` files included under Part India (`vecfield.typ`, `gcd.typ`, `work.typ`, `ftcgreen.typ`, `2dflux.typ`, `lineex.typ`, `mt3.typ`). Found and fixed the following minor issues:

**`src/vecfield.typ`**
- Word-choice error: a whirlpool swirls around its *vortex*, not its "vertex".
- Word-choice error: the downstream function increases as you get farther from the *head* of the river (not "the bank", which refers to the side rather than position along the river).
- Grammar: "I want tell you" → "I want to tell you".
- Grammar: "the gradient creates into a vector field" → "the gradient creates a vector field".
- Duplicate word: "what this means for each individual red arrow means" → "...for each individual red arrow".

**`src/work.typ`**
- Typo: "Then notation" → "The notation".
- Calculation error: in the bare-hands work example, the vector field was evaluated as `F(0, 1-2t)` but the parametrization is `r(t) = (1-2t, 0)`, so it should be `F(1-2t, 0)`. (The displayed final vector `(0, 3-6t)` was already correct, only the intermediate function-application notation had the arguments swapped.)

**`src/ftcgreen.typ`**
- The prose said to "integrate ... from 0 to π/2" while the displayed integral correctly used bounds 0 to π — fixed the prose to match.
- The displayed antiderivative `-cos(2t) - cos(t)` was missing a factor of 1/4 and had the wrong sign on `cos(t)`; corrected to `-cos(2t)/4 + cos(t)`, which integrates the given integrand correctly and yields the stated answer of `-2`.
- Grammar: "will always just equal to $c$" → "will always just equal $c$".

**`src/2dflux.typ`**
- In a flux example, the rotated vector field $vec(-q,p)$ was mislabeled as `vec(cos(t)^2, sin(t)^2)` (which is actually $vec(p,q)$); corrected to `vec(-sin(t)^2, cos(t)^2)`, and fixed the subsequent dot-product expansion to match. The final boxed answer was unaffected.

No large mathematical errors were found; all final boxed answers in this part were independently re-derived and confirmed correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMijLPRLuzh3yiDeZNZeA)_