### PR TITLE
fix: proofread solutions for Part India

### DIFF
--- a/src/sol-india.typ
+++ b/src/sol-india.typ
@@ -49,10 +49,10 @@ Since $rho^3 = (x^2 + y^2 + z^2)^(3 \/ 2)$, the chain rule gives
 $ (partial) / (partial x) (rho^3) = 3 / 2 (x^2 + y^2 + z^2)^(1 \/ 2) dot 2 x = 3 x rho. $
 Hence, the quotient rule gives
 $ (partial) / (partial x) x/rho^3
-  = (rho^3 dot 1 - x dot 3 x rho) / (r^6) = (rho^2 - 3x^2) / rho^5. $
+  = (rho^3 dot 1 - x dot 3 x rho) / (rho^6) = (rho^2 - 3x^2) / rho^5. $
 Now the divergence is given by
 $ nabla dot bf(G) &=
-  -G m ((partial) / (partial x) x/rho^3 + (partial) / (partial x) y/rho^3 + (partial) / (partial x) z/rho^3) \
+  -G m ((partial) / (partial x) x/rho^3 + (partial) / (partial y) y/rho^3 + (partial) / (partial z) z/rho^3) \
   &= -G m ((rho^2 - 3x^2) / rho^5 + (rho^2 - 3y^2) / rho^5 + (rho^2 - 3z^2) / rho^5) \
   &= -G m (3rho^2 - 3(x^2+y^2+z^2)) / rho^5 \
   &= 0 $
@@ -89,7 +89,7 @@ $ bf(F)(bf(r)(t)) = bf(F)(1-t,0) = vec((1-t)^2, 1)
   bf(r)'(t) = vec(-1, 0). $
 Then
 $ int_(cal(C)_2) bf(F) dot dif bf(r)
-  &= int_(t=-1)^1 vec((1-t)^2, 1) dot vec(-1, 0) dif t \
+  &= int_(t=0)^2 vec((1-t)^2, 1) dot vec(-1, 0) dif t \
   &= int_(t=0)^2 - (1 - t)^2 dif t \
   &= - 2 / 3 . $
 Putting this all together we get
@@ -253,7 +253,7 @@ $ bf(F)(bf(r)(t)) = bf(F)(1-t,0) = vec((1-t)^2, 1)
   bf(r)'(t) = vec(-1, 0). $
 Rotating $bf(F)$ as in @sec-recipe-2d-flux, we have
 $ int_(cal(C)_2) bf(F) dot bf(n) dif s
-  &= int_(t=-1)^1 vec(-1, (1-t)^2) dot vec(-1, 0) dif t \
+  &= int_(t=0)^2 vec(-1, (1-t)^2) dot vec(-1, 0) dif t \
   &= int_(t=0)^2 1 dif t \
   &= 2. $
 
@@ -274,12 +274,12 @@ The region $cal(R)$ hasn't changed and is given by
 $ -1 <= x <= 1 \ x^2-1 <= y <= 0. $
 Hence from Green's theorem, we have
 $ int_(cal(C)) bf(F) dot bf(n) dif s
-  &= iint_(cal(R)) ((partial Q) / (partial x) - (partial P) / (partial y)) dif A \
+  &= iint_(cal(R)) ((partial P) / (partial x) + (partial Q) / (partial y)) dif A \
   &= int_(x=- 1)^1 int_(y=x^2 - 1)^0 2(x+1)(y+1) dif y dif x \
   &= int_(x=- 1)^1 (x+1) int_(y=x^2 - 1)^0 2(y+1) dif y dif x \
   &= int_(x=- 1)^1 (x+1) (1-x^4) dif x \
   &= int_(x=- 1)^1 (-x^5-x^4+x+1) dif x \
-  &= [-x^6/6 - x^5/5 + x^2 + x]_(x=-1)^1 = #boxed[$ 8/5 $]. $
+  &= [-x^6/6 - x^5/5 + x^2/2 + x]_(x=-1)^1 = #boxed[$ 8/5 $]. $
 
 == Solution to @exer-flux-triangle (flux across a triangle)
 
@@ -528,7 +528,7 @@ $ op("Area")(cal(R))
   = int_(y=0)^1 ((e-1)^2 - (e^y-1)^2) dif y \
   &= e^2-2e - int_(y=0)^1 (e^(2y) - 2e^y) dif y
   = e^2-2e - lr([e^(2y)/2 - 2e^y])_(y=0)^1 \
-  &= e^2-2e - (e^2/2 - 2e) - (1/2-2) = #boxed[$ (e^2-3)/2 $]. $
+  &= e^2-2e - (e^2/2 - 2e) + (1/2-2) = #boxed[$ (e^2-3)/2 $]. $
 
 #remark[
   It is also possible to calculate an antiderivative of $log(sqrt(x)+1)$ directly


### PR DESCRIPTION
Closes #67.

Proofread `src/sol-india.typ` (solutions for Part India). Found and fixed:

- **`exer-gravity-div1`**: the quotient-rule denominator was written as `(r^6)` instead of `(rho^6)` (`r` is never defined; only `rho` is used throughout). Also, the divergence sum applied `partial/partial x` to all three terms instead of `partial/partial x`, `partial/partial y`, `partial/partial z` respectively.
- **`exer-parabola-1`** and **`exer-parabola-3`**: the $\mathcal{C}_2$ line-integral and flux-integral setups both displayed the bounds as `t=-1` to `1` (copy-pasted from the $\mathcal{C}_1$ computation) before immediately correcting to `t=0` to `2` on the very next line; fixed the first line's bounds to match.
- **`exer-parabola-3`** (Green's theorem method): the flux formula was written using the curl form `(partial Q/partial x - partial P/partial y)` instead of the correct divergence form `(partial P/partial x + partial Q/partial y)` used for flux; the numeric substitution that followed already used the correct divergence value, so only the displayed formula was wrong. Also restored a missing factor of `1/2` in the `x^2/2` antiderivative term (this didn't change the boxed answer, since it cancels by symmetry over the `[-1,1]` bounds, but the displayed antiderivative was still incorrect).
- **`exer-mt3-log`**: a sign error when distributing the bracket evaluation `[e^(2y)/2 - 2e^y]` from `0` to `1` led to subtracting instead of adding the `y=0` term; fixed so the algebra is internally consistent (the boxed answer `(e^2-3)/2` was already correct).

No large mathematical errors were found; all other solutions in the file (touch grass, poster, work-given-angle, conservativeness check, work-boring, shoelace formula, flux-triangle, mt3-butterfly, mt3-green, mt3-chvar, mt3-polar, mt3-consv) were independently re-derived and check out correctly.

## Test plan
- Installed `typst` 0.15.0 plus the `@local/evan:1.0.0` package and required `@preview` deps (`gentle-clues`, `linguify`), then ran `typst compile lamv.typ` end-to-end (with placeholder SVGs standing in for Asymptote figures, since `asy` isn't available in this environment) — compiles cleanly with no errors.
- Ran `codespell` on the file — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AhCH61DaZuipXvCWk8mA3f)_