### PR TITLE
fix: Proofread Part Juliett (flux integrals of vector fields over a surface)

### DIFF
--- a/src/badstokes.typ
+++ b/src/badstokes.typ
@@ -23,7 +23,7 @@ Here's the statement of the result:
 
 #memo(title: [Classical Stokes' theorem])[
   Let $cal(C)$ be a closed loop in $RR^3$ parametrized by $bf(r)_1(t)$.
-  Suppose $cal(S)$ is the boundary of an oriented surface $cal(S)$ parametrized by $bf(r)_2(u,v)$.
+  Suppose $cal(C)$ is the boundary of an oriented surface $cal(S)$ parametrized by $bf(r)_2(u,v)$.
   Assume the orientation of $cal(C)$ and $cal(S)$ are compatible.
   Then
   $ underbrace(oint_(cal(C)) bf(F) dot dif bf(r)_1, = int_(t="start")^("stop") bf(F) dot bf(r)'_1(t) dif t)

--- a/src/divthm.typ
+++ b/src/divthm.typ
@@ -134,7 +134,7 @@ We can jump straight into examples now!
     = (int_(x=0)^a x dif x) (int_(y=0)^a dif y) (int_(z=0)^a dif z)
     = a^2/2 dot a dot a = a^4/2. $
   In any case, we get an answer of
-  $ 2 dot a^4/2 + 2 dot a^4/2 + 2 dot a^4 /2 = #boxed[$ 3a^4 $] #qedhere. $
+  $ 2 dot a^4/2 + 2 dot a^4/2 + 2 dot a^4 /2 = #boxed[$ 3a^4 $]. #qedhere $
 ]
 
 #sample[
@@ -275,7 +275,7 @@ and then you add a layer of plastic wrap on the bowl.
   so its flux integral is easy to calculate:
   from @table-surfcross-2 we choose $bf(n) dif S = chevron.l 0, 0, -1 chevron.r$ and hence
   $ iint_(cal(S)_("lid")) bf(F) dot bf(n) dif S
-    &= iint_(x^2+y^2 <= 1) chevron.l x + tan 0, y + e^0, 1 chevron.r dot chevron.l 0,0, -1 chevron.r dif x dif y
+    &= iint_(x^2+y^2 <= 1) chevron.l x + tan 0, y + e^0, 1 chevron.r dot chevron.l 0,0, -1 chevron.r dif x dif y \
     &= iint_(x^2+y^2 <= 1) (-1) dif x dif y = -pi. $
 
   So when we apply the divergence theorem, we get that

--- a/src/flux.typ
+++ b/src/flux.typ
@@ -50,7 +50,7 @@ $lr(chevron.l - (partial f) / (partial x), - (partial f) / (partial y), 1 chevro
 is less messy than $sqrt(1 + ((partial f) / (partial x))^2 + ((partial f) / (partial y))^2)$.
 
 We'll do example calculations in a moment, but let me first talk about how to think about this,
-and also explain what the adjective "oriented".
+and also explain what the adjective "oriented" means.
 
 == [TEXT] Aquatic interpretation of flux
 
@@ -131,14 +131,14 @@ Here's another example of an orientation to make things less abstract.
 #example(title: [Example: Orienting a sphere])[
   Let's consider the sphere $x^2 + y^2 + z^2 = 1$ with $z > 0$.
   For each point $P$ on the sphere, the normal vector to the sphere at $P$
-  either points straight towards the center of from $P$, or away from the center of $P$.
+  either points straight towards the center, or away from the center.
 
   What does this correspond to algebraically?
   We consider two possible ways to parametrize the sphere that differ only in the order.
 
   - Let's imagine we used a spherical parametrization of the hemisphere as
     $ bf(r)(phi, theta) = (sin phi cos theta, sin phi sin theta, cos phi) $
-    where $0 <= phi <= pi$ and $0 <= theta <= 2 pi$.
+    where $0 <= phi <= pi/2$ and $0 <= theta <= 2 pi$.
     If we grinded out the cross product, you would find that
     (see @ch-surfcross to see this written out)
     $ (partial bf(r)) / (partial phi) times (partial bf(r)) / (partial theta)
@@ -151,7 +151,7 @@ Here's another example of an orientation to make things less abstract.
   - But what if we had flipped the order of $phi$ and $theta$?
     That is, suppose we used
     $ bf(r)(theta, phi) = (sin phi cos theta, sin phi sin theta, cos phi) $
-    where $0 <= theta <= 2 pi$  and $0 <= phi <= pi$ instead.
+    where $0 <= theta <= 2 pi$  and $0 <= phi <= pi/2$ instead.
     Then the cross product will get negated:
     $ (partial bf(r)) / (partial theta) times (partial bf(r)) / (partial phi)
       = -sin phi dot (sin phi cos theta, sin phi sin theta, cos phi)
@@ -325,7 +325,7 @@ Let's give one example corresponding to each row of @table-surfcross-2.
   instead.
   The question wanted the normal vector to be oriented upwards, and since $1$ is positive,
   the original we had is okay; we use
-  $ bf(n) dif S = vec(3 x^2, 3 y^2, -1) = vec(- 3 x^2 , - 3 y^2, 1) dif x dif y. $
+  $ bf(n) dif S = vec(- 3 x^2 , - 3 y^2, 1) dif x dif y. $
 
   Now, the vector field is given at each point $(x,y)$ by
   $ bf(F)(bf(r)(x,y)) = vec(1 , 1 , x^3 + y^3). $
@@ -460,7 +460,7 @@ Let's give one example corresponding to each row of @table-surfcross-2.
   by using $cos^2 theta = (1 + cos(2 theta)) / 2$ and $sin^2 theta = (1 - cos(2 theta)) / 2$.
   Hence,
   $ 490 int_(theta=0)^(2 pi) (3 cos^2 theta + 5 sin^2 theta) dif theta
-    = 490 dot (3 pi + 8 pi) = #boxed[$ 3920 pi $]. #qedhere $
+    = 490 dot (3 pi + 5 pi) = #boxed[$ 3920 pi $]. #qedhere $
 ]
 
 For the final example, we actually use the same hemisphere again,
@@ -493,10 +493,10 @@ but this time we use spherical coordinates, so you can compare the methods.
       &= -1250 (sin^3 phi cos phi sin theta cos theta). $
   In other words, we have
   $ iint_(cal(S)) bf(F) dot bf(n) dif S
-    &= -1250 int_(theta=0)^(2 pi) int_(phi=0)^(pi / 2) sin^3 phi cos theta sin theta dif phi dif theta \
+    &= -1250 int_(theta=0)^(2 pi) int_(phi=0)^(pi / 2) sin^3 phi cos phi sin theta cos theta dif phi dif theta \
     &= -1250
       (int_(theta=0)^(2 pi) sin theta cos theta dif theta)
-      (int_(phi=0)^(pi/2) sin^3 phi cos phi dif phi.) $
+      (int_(phi=0)^(pi/2) sin^3 phi cos phi dif phi). $
   The latter integral is super annoying to evaluate,
   but the former integral is zero because $sin theta cos theta = 1/2 sin(2theta)$,
   so we don't have to worry about the $dif phi$ integral at all; we just get $#boxed[$ 0 $]$
@@ -573,9 +573,9 @@ Here are two examples of this with spheres.
   $bf(G)$ exerted has magnitude $(G m) / 17^2$ and points in the _opposite_ direction as $bf(n)$.
   That is, $ bf(G) dot bf(n) = (-((G m) / (17^2)) bf(n)) dot (bf(n)) = -(G m) / 289. $
   Consequently,
-  $ iint_(cal(S)) bf(F) dot bf(n) dif S = -(G m) / 289 dot op("SurfArea")(cal(S))
+  $ iint_(cal(S)) bf(G) dot bf(n) dif S = -(G m) / 289 dot op("SurfArea")(cal(S))
     = (-G m)/(17^2) dot (4 dot 17^2 pi) = #boxed[$ -4 pi G m $]. $
-  (In general, we know a sphere of radius $R$ has surface area $R^2 pi$.)
+  (In general, we know a sphere of radius $R$ has surface area $4 R^2 pi$.)
 ]
 Note that the answer is independent of the radius! The $17$ cancels out.
 


### PR DESCRIPTION
Closes #68.

Proofread `src/flux.typ`, `src/divthm.typ`, `src/badstokes.typ` (the files included under Part Juliett). Found and fixed:

- `src/flux.typ`: incomplete sentence "explain what the adjective 'oriented'." was missing "means".
- `src/flux.typ`: in the sphere-orientation example, "either points straight towards the center of from $P$, or away from the center of $P$" was garbled; simplified to "either points straight towards the center, or away from the center."
- `src/flux.typ`: the same example parametrizes "the hemisphere" (sphere with $z>0$) but gave the bounds as $0 <= phi <= pi$ (the whole sphere) in both orderings; corrected to $0 <= phi <= pi/2$.
- `src/flux.typ`: in the $z = x^3+y^3$ flux sample, the displayed equation `vec(3x^2,3y^2,-1) = vec(-3x^2,-3y^2,1)` falsely equated a vector with its own negation; removed the erroneous first (negated) vector, since the dot product computed immediately afterward uses the non-negated one.
- `src/flux.typ`: in the cylinder flux sample, `490 dot (3 pi + 8 pi)` should be `490 dot (3 pi + 5 pi)` to match $int cos^2 = int sin^2 = pi$ (the final boxed answer of $3920 pi$ was already correct).
- `src/flux.typ`: in the spherical-coordinates hemisphere sample, a displayed integral dropped the $cos phi$ factor present in the line immediately before and the line immediately after it.
- `src/flux.typ`: in the point-mass-gravity flux sample, the dot-product line used $bf(F)$ instead of $bf(G)$ (the vector field is named $G$ in this example), and the general surface-area formula was given as "$R^2 pi$" instead of the correct "$4 R^2 pi$" (the actual computation in the same sample already used the correct $4 R^2 pi$).
- `src/divthm.typ`: a missing `\` line break caused two rows of an aligned equation to run together.
- `src/divthm.typ`: moved a stray period to match the `#boxed[...]. #qedhere` convention used everywhere else in the file.
- `src/badstokes.typ`: the classical Stokes' theorem statement said "Suppose $cal(S)$ is the boundary of an oriented surface $cal(S)$", which is self-referential nonsense; corrected to "Suppose $cal(C)$ is the boundary of an oriented surface $cal(S)$", consistent with the definition of compatible orientations given just above it.

No large mathematical errors were found beyond the sign/factor slips above.

## Test plan
- Installed `typst` 0.15.0 plus the `@local/evan:1.0.0` package (from `vEnhance/dotfiles`) and the required `@preview` deps (`gentle-clues`, `linguify`), generated placeholder SVGs standing in for the Asymptote figures (`asy` isn't available in this environment), then ran `typst compile lamv.typ` end-to-end — compiles cleanly with no errors.
- Ran `codespell` on the three changed files — no issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_019s4SnXrKoKvtcpmmTmCQLL)_