### PR TITLE
fix: proofread solutions for Part Juliett

### DIFF
--- a/src/sol-juliett.typ
+++ b/src/sol-juliett.typ
@@ -39,7 +39,7 @@ $ nabla dot bf(F) = (partial) / (partial x) (cos (z^2) - x)
 We seal the region $cal(S)$ by adding $cal(S)_"lid"$,
 the surface of points with $z = e$ and $x^2+y^2 <= 1$.
 This encloses a closed volume $cal(T)$.
-We orient the normal vector pointing upward (away from $cal(T)$).
+We orient $cal(S)_"lid"$'s normal vector pointing upward (away from $cal(T)$).
 Note $cal(S)$ also has normal vector pointing away from $cal(T)$.
 
 The divergence theorem on $cal(S)$ and $cal(S)_"lid"$, enclosing $cal(T)$, now gives
@@ -68,8 +68,8 @@ We consider the solid volume $cal(T)$ contained between $cal(S)_1$ and $cal(S)_2
 Since $cal(S)_2$ has normal vector oriented toward $cal(T)$
 while $cal(S)_1$ has normal vector oriented away from $cal(T)$,
 the divergence theorem says that
-$ iint_(cal(S)_2) bf(G) dot bf(n) dif S
-  - iint_(cal(S)_1) bf(G) dot bf(n) dif S
+$ iint_(cal(S)_1) bf(G) dot bf(n) dif S
+  - iint_(cal(S)_2) bf(G) dot bf(n) dif S
   = iiint_(cal(T)) nabla dot bf(G) dif V. $
 
 #figure(


### PR DESCRIPTION
Closes #69.

Proofread `src/sol-juliett.typ` (solutions for Part Juliett). Found and fixed two issues:

- **`exer-flux-sealing`**: clarified an ambiguous sentence that said "We orient the normal vector pointing upward" without naming which surface; the orientation choice being described is for $cal(S)_"lid"$, not $cal(S)$ (whose orientation is already fixed by the problem statement). Specified the surface explicitly.
- **`exer-gravity-div2`**: the divergence theorem identity had the two surface-flux terms subtracted in the wrong order. Given that $cal(S)_1$'s normal points away from $cal(T)$ (matching the outward-from-$cal(T)$ orientation) while $cal(S)_2$'s normal points toward $cal(T)$ (opposite the outward-from-$cal(T)$ orientation), correctly applying the divergence theorem gives `iint_(S1) - iint_(S2) = iiint_T div`, not `iint_(S2) - iint_(S1)` as written. I verified the corrected sign by direct computation with a radial test field ($bf(F) = chevron.l x,y,z chevron.r$, $div bf(F) = 3$) on concentric spheres of radius 1 and 2: $32pi - 4pi = 28pi$ matches $iiint_T 3 dif V = 28pi$, confirming `iint_(S1) - iint_(S2)` is the correct order. Since this exercise has $div bf(G) = 0$, the final boxed conclusion ($oiint_(S_1) = oiint_(S_2)$) is unaffected either way, but the intermediate identity as stated was incorrect in general.

No other mathematical errors were found; the remaining solutions (flux through $x^3+y^4=e^z$, divergence-to-Green, Stokes-to-Green) were independently re-derived and check out correctly.

## Test plan
- Installed `typst` 0.15.0 plus the `@local/evan:1.0.0` package (from `vEnhance/dotfiles`) and the required `@preview` deps (`gentle-clues`, `linguify`), generated placeholder SVGs standing in for the Asymptote figures (`asy` isn't available in this environment), then ran `typst compile lamv.typ` end-to-end — compiles cleanly with no errors.
- Ran `codespell` on the file — no issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_012MAUxHgBxnMLHWiU62jeRR)_