### PR TITLE
fix: Proofread Part Kilo (practice questions)

### DIFF
--- a/src/practice.typ
+++ b/src/practice.typ
@@ -2,7 +2,7 @@
 
 = Practice questions <ch-practice>
 
-Some practice questions from topics through the entire course.
+Some practice questions from topics throughout the entire course.
 Solutions are in @ch-sol-kilo.
 
 == Practice half-final
@@ -12,7 +12,7 @@ It was about half the length of the final exam (which was 14 questions long).
 
 #exer[
   Give an example of a complex number $z$ whose
-  real and imaginary part are both negative such that $z^3 = - 1000 i$.
+  real and imaginary parts are both negative such that $z^3 = - 1000 i$.
   Write your answer in rectangular form.
 ] <exer-mf-1>
 


### PR DESCRIPTION
Closes #70.

Proofread `src/practice.typ` (the only file included under Part Kilo in `lamv.typ`). Found two minor wording/grammar issues:

- "topics through the entire course" → "topics throughout the entire course", matching the consistent usage of "throughout" elsewhere in the book (e.g. `src/dot.typ`, `src/tsafe.typ`, `src/preface.typ`, `src/grad.typ`).
- "real and imaginary part are both negative" → "real and imaginary parts are both negative" (standard plural terminology).

I checked the math content of all practice problems (eigenvalues, line/flux integrals, critical points, etc.) against the worked solutions in `extras/mockfin.typ` where available, and did not find any computational errors — only the wording issues above.

Note: the same "real and imaginary part" typo also appears in `src/sol-kilo.typ` and `extras/mockfin.typ`, but those are out of scope for this issue (sol-kilo.typ is tracked separately by #71).

---
_Generated by [Claude Code](https://claude.ai/code/session_011TV7BAWNr5fx9B5rDaJsBM)_